### PR TITLE
minor fixes to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_new-initiative.yaml
+++ b/.github/ISSUE_TEMPLATE/01_new-initiative.yaml
@@ -9,7 +9,7 @@ body:
     label: Problem Statement
     description: |
       A specific problem being faced by one or more specific personas
-      (such as student, researcher, instructor, end user, jupyterhub admin, 2i2c engineer, university IT admin, PI, etc)
+      (such as student, researcher, instructor, end user, JupyterHub admin, 2i2c engineer, university IT admin, PI, etc.)
       we care about.
 
     value: |
@@ -27,7 +27,7 @@ body:
   attributes:
     label: Proposed Implementation
     description: |
-      A very broad description of how we propose to technicall implement this solution.
+      A very broad description of how we propose to technically implement this solution.
 
 - type: textarea
   id: fits


### PR DESCRIPTION
capitalizes "jupyterhub" to "JupyterHub", fixes minor typo of "technicall" to "technically".